### PR TITLE
Fix League Points being interpreted as unknown

### DIFF
--- a/osrs_api/const.py
+++ b/osrs_api/const.py
@@ -12,10 +12,15 @@ class AccountType(Enum):
 
     @classmethod
     def normal_types(cls):
-        return [cls.NORMAL, cls.IRONMAN, cls.HARDCORE_IRONMAN, cls.ULTIMATE_IRONMAN]
+        return [cls.NORMAL,
+                cls.IRONMAN,
+                cls.HARDCORE_IRONMAN,
+                cls.ULTIMATE_IRONMAN]
 
 
-# Thanks to http://mirekw.com/rs/RSDOnline/Guides/guide.aspx?file=Experience%20formula.html for the formula
+# Thanks to
+# http://mirekw.com/rs/RSDOnline/Guides/guide.aspx?file=Experience%20formula.html
+# for the formula
 def _build_xp_table():
     table = [0]
     xp = 0
@@ -30,8 +35,6 @@ def _build_xp_table():
 
 # index retrives the amount of xp required for level index + 1
 XP_TABLE = _build_xp_table()
-
-UNUSED_OR_UNKNOWN = "UNUSED_OR_UNKNOWN"  # Use this as a placeholder for unknown API response rows
 
 SKILLS = [
     "attack",
@@ -60,7 +63,7 @@ SKILLS = [
 ]
 
 MINIGAMES = [
-    UNUSED_OR_UNKNOWN,
+    "League Points",
     "Bounty Hunter",
     "Bounty Hunter Rogue",
     "Clue Scrolls (all)",

--- a/osrs_api/hiscores.py
+++ b/osrs_api/hiscores.py
@@ -18,7 +18,7 @@ class Hiscores(object):
         self._api_response = None
 
         if self._type is None:
-            self._find_account_type() # _type is set inside _find_account_type
+            self._find_account_type()  # _type is set inside _find_account_type
 
         self.rank, self.total_level, self.total_xp = -1, -1, -1
 
@@ -29,7 +29,8 @@ class Hiscores(object):
         self.update()
 
     def update(self):
-        # In the default case (account_type=None), we already have this information. We don't need to do it again
+        # In the default case (account_type=None), we already have this
+        # information. We don't need to do it again
         if self._api_response is None:
             self._api_response = self._get_api_data()
         self._set_data()
@@ -50,7 +51,7 @@ class Hiscores(object):
                 self._type = possible_type
                 self._api_response = self._get_api_data()
                 return
-            except:
+            except BaseException:
                 pass
 
         self._raise_bad_username()
@@ -87,7 +88,7 @@ class Hiscores(object):
         # Get all the skills, minigames, or bosses
         def _get_api_chunk(cls, *, names, start_index):
             """
-            cls: Skill, Minigame, or Boss - Type of the chunk 
+            cls: Skill, Minigame, or Boss - Type of the chunk
             names: List[str] - a list of all the (Skill, Minigame, or Boss) names in the order the API returns them.
                    (const.SKILLS, const.MINIGAMES, or const.BOSSES)
             start_index: The index into self._api_response where the chunk begins
@@ -96,11 +97,13 @@ class Hiscores(object):
             chunk = {}
 
             for i, name in enumerate(names, start=start_index):
-                if name == const.UNUSED_OR_UNKNOWN:
+                if (self._type is not const.AccountType.SEASONAL and name ==
+                        "League Points"):
                     continue
 
                 # The API only returns integers
-                row_data = [int(col) for col in self._api_response[i].split(",")]
+                row_data = [int(col)
+                            for col in self._api_response[i].split(",")]
 
                 chunk[name] = cls(name, *row_data)
 


### PR DESCRIPTION
The last unknown parameter was seasonal league points, so I removed the unknown parameter from const and instead make it skip reading league points if the account type is not seasonal. I ran an autopep8 on it which is the reason for the other changes, I can undo it if you don't like it.

Nice project, btw :+1: 